### PR TITLE
Correct text role error on pelican 3.7.1 on Xubuntu 16.04

### DIFF
--- a/doc/pelican/writing-content.rst
+++ b/doc/pelican/writing-content.rst
@@ -32,6 +32,9 @@ Writing content
 
         `Pelican <{filename}/pelican.rst>`_ | `Theme » <{filename}/pelican/theme.rst>`_
 
+.. role:: rst(code)
+    :language: rst
+
 While the official `reStructuredText <http://docutils.sourceforge.net/rst.html>`_
 documentation provides an extensive syntax guide, the info is scattered across
 many pages. The following page will try to explain the basics and mention a


### PR DESCRIPTION
DEBUG: Read file pelican/writing-content.rst -> Page
/home/gotcha/m.css/site/content/pelican/writing-content.rst:72: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:122: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:143: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:143: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:143: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:218: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:226: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:264: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:357: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:357: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:357: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:357: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:363: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:363: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:363: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:363: (ERROR/3) Unknown interpreted text role "rst".
/home/gotcha/m.css/site/content/pelican/writing-content.rst:412: (ERROR/3) Unknown interpreted text role "rst".
Makefile:65: recipe for target 'html' failed
make: *** [html] Error 13